### PR TITLE
Create pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=42", "wheel", "Cython"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
We're finding that we need a `pyproject.toml` file in the root of the `bnpy` package to build it correctly in a barebones environment (that does not have Cython pre-installed). The rationale for this file is described in https://www.python.org/dev/peps/pep-0518/.

The included `pyproject.toml` is the simplest version of such a file, with the recommended versions of `setuptools` etc. specified.

The simplest scenario to see its effect in action:
```
conda --version
> conda 4.8.5

conda create --name bnpy python=3.8
conda activate bnpy
python -c "import setuptools; print(setuptools.__version__);"
> 50.3.1.post20201107

pip install git+https://github.com/bnpy/bnpy.git
...
 running build_ext
  building 'bnpy.util.SparseRespUtilX' extension
  error: unknown file type '.pyx' (from 'bnpy/util/SparseRespUtilX.pyx')
...
```

But with the inclusion of this file:

```
conda create --name bnpy python=3.8
conda activate bnpy
pip install git+https://github.com/raphael-group/bnpy
...
  Building wheel for bnpy (PEP 517) ... done
...
Successfully built bnpy
```

The `setup.py` file for `bnpy` does include a `setup_requires` section, but this has been deprecated for a little while in favor of a `pyproject.toml`, which perhaps explains why setuptools is unable to work with it in this case.
